### PR TITLE
Render table of contents above documentation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # Build stage: Install python dependencies
 # ===
 FROM ubuntu:focal AS python-dependencies
-RUN apt-get update && apt-get install --no-install-recommends --yes python3-pip python3-setuptools
+RUN apt-get update && apt-get install --no-install-recommends --yes python3-pip python3-setuptools git
 COPY requirements.txt /tmp/requirements.txt
 RUN pip3 config set global.disable-pip-version-check true
 RUN --mount=type=cache,target=/root/.cache/pip pip3 install --user --requirement /tmp/requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 canonicalwebteam.flask-base==1.1.0
-canonicalwebteam.discourse==5.1.4
+# canonicalwebteam.discourse==5.1.4
+git+https://github.com/canonical/canonicalwebteam.discourse@petesfrench-patch-1#egg=canonicalwebteam.discourse
 canonicalwebteam.search==1.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 canonicalwebteam.flask-base==1.1.0
 # canonicalwebteam.discourse==5.1.4
-git+https://github.com/canonical/canonicalwebteam.discourse@petesfrench-patch-1#egg=canonicalwebteam.discourse
+git+https://github.com/canonical/canonicalwebteam.discourse@wd-2017#egg=canonicalwebteam.discourse
 canonicalwebteam.search==1.3.0

--- a/templates/docs/document.html
+++ b/templates/docs/document.html
@@ -86,11 +86,34 @@
     </aside>
 
     <main class="col-9">
-      {% if document.title %}
       <div class="p-strip is-shallow is-bordered u-no-padding--top">
         <h1 class="u-no-margin--bottom">{{ document.title }}</h1>
       </div>
+      {% if document.headings_map and not document.disable_toc %}
+      <div class="p-strip is-shallow u-no-padding--bottom">
+        <ol class="p-list--nested-counter">
+          {% for heading in document.headings_map %}
+          <li>
+            <a href="#{{ heading.heading_slug }}">
+              {{ heading.heading_text }}
+            </a>
+            {% if heading.children %}
+              <ol>
+                {% for sub_heading in heading.children %}
+                  <li>
+                    <a href="#{{ sub_heading.heading_slug }}">
+                      {{ sub_heading.heading_text }}
+                    </a>
+                  </li>
+                {% endfor %}
+              </ol>
+            {% endif %}
+          </li>
+          {% endfor %}
+        </ol>
+      </div>
       {% endif %}
+
       <div class="p-strip is-shallow" style="overflow: visible;">
       {{ document.body_html | safe }}
       </div>


### PR DESCRIPTION
## Done

**Before merging update the requirements folder to use a live version of the discourse module and remove 'git' from dockerfile, see screenshot below **
- Renders a table of contents above documentation, used [this version of the discourse module](https://github.com/canonical/canonicalwebteam.discourse/pull/154)

## QA

- Go to a documentation page, for example, https://microk8s-io-584.demos.haus/docs/configure-host-interfaces and see that a table of contents is rendered using the h2 and h3 headings on the page and that clicking on them navigates you to that heading in the page.


## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-2167

![image](https://user-images.githubusercontent.com/58276363/220954396-9533faac-f232-4c92-b576-8e0a8377b371.png)
