### PR TITLE
move addon commands onto separate lines

### DIFF
--- a/templates/partial/_get-started-linux.html
+++ b/templates/partial/_get-started-linux.html
@@ -43,7 +43,10 @@
           <div class="col-6">
             <div class="p-stepped-list__content">
               <div class="p-code-snippet">
-                <pre class="p-code-snippet__block"><code>microk8s enable dashboard dns registry istio</code></pre>
+                <pre class="p-code-snippet__block"><code>microk8s enable dashboard</code></pre>
+                <pre class="p-code-snippet__block"><code>microk8s enable dns</code></pre>
+                <pre class="p-code-snippet__block"><code>microk8s enable registry</code></pre>
+                <pre class="p-code-snippet__block"><code>microk8s enable istio</code></pre>
               </div>
               <p>Try <code>microk8s enable --help</code> for a list of available services and optional features. <code>microk8s disable &lt;name&gt;</code> turns off a service.</p>
             </div>     

--- a/templates/partial/_get-started-macos.html
+++ b/templates/partial/_get-started-macos.html
@@ -49,7 +49,10 @@
           <div class="col-6">
             <div class="p-stepped-list__content">
               <div class="p-code-snippet">
-                <pre class="p-code-snippet__block"><code>microk8s enable dashboard dns registry istio</code></pre>
+                <pre class="p-code-snippet__block"><code>microk8s enable dashboard</code></pre>
+                <pre class="p-code-snippet__block"><code>microk8s enable dns</code></pre>
+                <pre class="p-code-snippet__block"><code>microk8s enable registry</code></pre>
+                <pre class="p-code-snippet__block"><code>microk8s enable istio</code></pre>
               </div>
               <p>
                 Try <code>microk8s enable --help</code> for a list of available services built in. <code>microk8s disable</code> turns off a service.

--- a/templates/partial/_get-started-windows.html
+++ b/templates/partial/_get-started-windows.html
@@ -72,7 +72,10 @@
           <div class="col-6">
             <div class="p-stepped-list__content">
               <div class="p-code-snippet">
-                <pre class="p-code-snippet__block"><code>microk8s enable dashboard dns registry istio</code></pre>
+                <pre class="p-code-snippet__block"><code>microk8s enable dashboard</code></pre>
+                <pre class="p-code-snippet__block"><code>microk8s enable dns</code></pre>
+                <pre class="p-code-snippet__block"><code>microk8s enable registry</code></pre>
+                <pre class="p-code-snippet__block"><code>microk8s enable istio</code></pre>
               </div>
               <p>
                 Try <code>microk8s enable --help</code> for a list of available services built in. microk8s disable turns off a service.


### PR DESCRIPTION
## Done

changes the addon commands to be on separate lines

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8027/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- [List additional steps to QA the new features or prove the bug has been resolved]


## Issue / Card

Fixes #619
