### PR TITLE
Bump canonicalwebteam.discourse to 5.4.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 canonicalwebteam.flask-base==1.1.0
-canonicalwebteam.discourse==5.4.2
+canonicalwebteam.discourse==5.4.3
 canonicalwebteam.search==1.3.0


### PR DESCRIPTION
## Done

Bump canonicalwebteam.discourse to 5.4.3

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8027/
- Browse the discourse powered sections in the demo environment and check they work.
