### PR TITLE
Add missing charset meta tag

### DIFF
--- a/templates/base_layout.html
+++ b/templates/base_layout.html
@@ -12,6 +12,7 @@
 
 <head>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta charset="utf-8">
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
 


### PR DESCRIPTION
Noticed on Ecosia and Bing that the description of the page is garbled and I wonder if it could be fixed with this meta tag

## Done

+ Add a meta tag for charset

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8027/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- [List additional steps to QA the new features or prove the bug has been resolved]


## Issue / Card

Fixes #628

## Screenshots

N/A
