### PR TITLE
Bump canonicalwebteam.discourse from 5.4.3 to 5.4.9

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 canonicalwebteam.flask-base==1.1.0
-canonicalwebteam.discourse==5.4.3
+canonicalwebteam.discourse==5.4.9
 canonicalwebteam.search==1.3.0


### PR DESCRIPTION
## Done

Bump canonicalwebteam.discourse to 5.4.9

## QA

- Trying to access <http://127.0.0.1:8027/docs/command-reference>, an internal error was thrown:
  ```bash
  Traceback (most recent call last):
    File "/usr/local/lib/python3.8/dist-packages/flask/app.py", line 2450, in wsgi_app
      response = self.handle_exception(e)
    File "/usr/local/lib/python3.8/dist-packages/flask/app.py", line 1867, in handle_exception
      reraise(exc_type, exc_value, tb)
    File "/usr/local/lib/python3.8/dist-packages/flask/_compat.py", line 39, in reraise
      raise value
    File "/usr/local/lib/python3.8/dist-packages/flask/app.py", line 2447, in wsgi_app
      response = self.full_dispatch_request()
    File "/usr/local/lib/python3.8/dist-packages/flask/app.py", line 1952, in full_dispatch_request
      rv = self.handle_user_exception(e)
    File "/usr/local/lib/python3.8/dist-packages/flask/app.py", line 1821, in handle_user_exception
      reraise(exc_type, exc_value, tb)
    File "/usr/local/lib/python3.8/dist-packages/flask/_compat.py", line 39, in reraise
      raise value
    File "/usr/local/lib/python3.8/dist-packages/flask/app.py", line 1950, in full_dispatch_request
      rv = self.dispatch_request()
    File "/usr/local/lib/python3.8/dist-packages/flask/app.py", line 1936, in dispatch_request
      return self.view_functions[rule.endpoint](**req.view_args)
    File "/usr/local/lib/python3.8/dist-packages/canonicalwebteam/discourse/app.py", line 183, in document_view
      document = self.parser.parse_topic(topic, docs_version)
    File "/usr/local/lib/python3.8/dist-packages/canonicalwebteam/discourse/parsers/docs.py", line 124, in parse_topic
      sections = self._get_sections(soup)
    File "/usr/local/lib/python3.8/dist-packages/canonicalwebteam/discourse/parsers/base_parser.py", line 450, in _get_sections
      section_soup = self._get_section(soup, heading.text)
    File "/usr/local/lib/python3.8/dist-packages/canonicalwebteam/discourse/parsers/base_parser.py", line 483, in _get_section
      if heading.string is None and heading.a.next == title_text:
  AttributeError: 'NoneType' object has no attribute 'next'
  ```
- Bump to include the following [change](https://github.com/canonical/canonicalwebteam.discourse/commit/cb96750bca76dd8fc05dd58929303087e9f40eca) introduced to 5.4.4 and on.
- <http://127.0.0.1:8027/docs/command-reference> is accessible since error is gone (screenshot included)

## Issue / Card

Fixes #637

## Screenshots

![image](https://github.com/canonical/microk8s.io/assets/4290399/85551f14-c77b-48be-adb7-0c94c7340cdd)
