### PR TITLE
Anchor link DEMO

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "postcss": "8.4.21",
     "postcss-cli": "10.1.0",
     "sass": "1.57.1",
-    "vanilla-framework": "4.5.0",
+    "vanilla-framework": "4.10.0",
     "webpack-cli": "5.0.1"
   },
   "devDependencies": {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 canonicalwebteam.flask-base==1.1.0
-canonicalwebteam.discourse==5.4.9
+canonicalwebteam.discourse @ git+https://github.com/canonical/canonicalwebteam.discourse@heading-anchor-links
 canonicalwebteam.search==1.3.0

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -16,6 +16,7 @@
 @import "pattern_resources";
 @include microk8s-github-buttons;
 @include canonical-p-footer;
+@include vf-p-icon-get-link;
 
 // Custom styles
 .p-tab {
@@ -162,7 +163,7 @@
   }
 
   &:after {
-    @extend .p-icon--anchor;
+    @extend .p-icon--get-link;
     content: "¶";
     display: inline-block;
     padding: 1rem;

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -162,10 +162,13 @@
   }
 
   &:after {
+    @extend .p-icon--anchor;
     content: "¶";
     display: inline-block;
+    padding: 1rem;
+    top: 0.6rem;
     visibility: hidden;
-    margin-left: 0.5rem;
+    margin-left: 0.75rem;
   }
 
   &:hover {

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -153,3 +153,24 @@
     padding-left: 0.5rem;
   }
 }
+
+.p-anchor-link {
+  color: $color-dark;
+
+  &:visited {
+    color: $color-dark;
+  }
+
+  &:after {
+    content: "¶";
+    display: inline-block;
+    visibility: hidden;
+    margin-left: 0.5rem;
+  }
+
+  &:hover {
+    &::after {
+      visibility: visible;
+    }
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5451,10 +5451,10 @@ vanilla-framework@4.0.0:
   resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-4.0.0.tgz#a2fee9bd9763ebd6932b764f9d66484dc177d4cc"
   integrity sha512-fiPnmaTUe15l5MRNJ6IsiJ8qiunfmgtLETOFltaYiE/bQKL7xTI+riBak2iygBKeF1y0Gi/GxUNt4hyb6xDPKA==
 
-vanilla-framework@4.5.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-4.5.0.tgz#992332239682821094defaae0e8aacd343bf9239"
-  integrity sha512-35q360QpJirosK7403fSQLRPXsdabZ6LdkP2x5bqJBak3rkwmYE34wOqGbm0KggQLXSZimW5ZP2Y+0LohtAF+w==
+vanilla-framework@4.10.0:
+  version "4.10.0"
+  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-4.10.0.tgz#09fba5c31f93f46306b51f519d0b5f3b7363d73d"
+  integrity sha512-mkf48XSjU11KxmikB63+vnHxncqyYEjl9ki5dCD/oL2AGdh53t2uHsh2z85jMyz8MMXcHlXo2/gWIsSQluS/Vg==
 
 verbalize@^0.1.2:
   version "0.1.2"


### PR DESCRIPTION
**As the git method is not available in our demo environment, you will need to run this locally to test it**
*This is just for demoing purposes, I would like to upstream this to vanilla*

## Done

- Add style for discourse module update that allows anchor tags on headings

## QA

- Go to https://microk8s-io-642.demos.haus/docs/howto-addons and hover over one of the h2 headings
- See that it is clickable and has a fun shape next to it
- Click it and see the anchor tag in the url update :exploding_head: 

## Issue / Card

Fixes #

## Screenshots

[if relevant, include a screenshot]
