### PR TITLE
Update install microk8s on windows tutorial href

### DIFF
--- a/templates/tutorials/index.html
+++ b/templates/tutorials/index.html
@@ -20,7 +20,7 @@
   <div class="row p-section--shallow">
     <hr class="p-rule">
     <div class="col-6 col-medium-3">
-      <h2 class="p-heading--4"><a href="https://ubuntu.com/tutorials/install-microk8s-on-windows#1-overview">Install MicroK8s on Windows</a></h2>
+      <h2 class="p-heading--4"><a href="https://microk8s.io/docs/install-windows">Install MicroK8s on Windows</a></h2>
     </div>
     <div class="col-4 col-medium-2">
       <p>Get a local Kubernetes on Windows with MicroK8s and&nbsp;Multipass.</p>


### PR DESCRIPTION
## Done

- Update install microk8s on windows tutorial href to redirect to: [](https://microk8s.io/docs/install-windows) since the current one doesn't exist and throws 404 error.

## QA

- View the site locally in your web browser
- See that the requested change was made

## Issue / Card

Fixes [#643 ](https://github.com/canonical/microk8s.io/issues/643)