### PR TITLE
Fix /features link

### DIFF
--- a/templates/features/high-availability.html
+++ b/templates/features/high-availability.html
@@ -30,7 +30,7 @@
         <p>Autonomy combined with high availability delivers a full Kubernetes with minimal setup, able to support mission-critical workloads with operational efficiency.</p>
         <p>MicroK8s uses Dqlite, a high-availability SQLite, as its datastore. As soon as the cluster includes three or more nodes, Dqlite is resilient and the API services are distributed on all of them. If one node should fail or be restarted, Kubernetes keeps running and will recover itself back to full HA when the node becomes available again, with no administrative action. </p>
         <p>
-          <a>Learn more about how HA MicroK8s works&nbsp;&rsaquo;</a>
+          <a href="/docs/high-availability">Learn more about how HA MicroK8s works&nbsp;&rsaquo;</a>
         </p>
       </div>
     </div>


### PR DESCRIPTION
## Done

- Added missing href

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: https://microk8s-io-650.demos.haus/features#high-availability 
- Click on the "Learn more about how HA microk8s works" link and see that you're routed correctly as per [doc](https://docs.google.com/document/d/1G6FijpahZCSfxcuFAkv22wKCILEkF2u4Q0TQUfkW5i4/edit)


## Issue / Card

Reported on [MM](https://chat.canonical.com/canonical/pl/csejuqo6ktf3pkpwkwt1m6h9nr)