### PR TITLE
WD-12939 - update canonicalwebteam.discourse to 5.6.1 and vanilla to …

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "postcss": "8.4.21",
     "postcss-cli": "10.1.0",
     "sass": "1.57.1",
-    "vanilla-framework": "4.5.0",
+    "vanilla-framework": "4.14.0",
     "webpack-cli": "5.0.1"
   },
   "devDependencies": {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 canonicalwebteam.flask-base==1.1.0
-canonicalwebteam.discourse==5.4.9
+canonicalwebteam.discourse==5.6.1
 canonicalwebteam.search==1.3.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -5451,10 +5451,10 @@ vanilla-framework@4.0.0:
   resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-4.0.0.tgz#a2fee9bd9763ebd6932b764f9d66484dc177d4cc"
   integrity sha512-fiPnmaTUe15l5MRNJ6IsiJ8qiunfmgtLETOFltaYiE/bQKL7xTI+riBak2iygBKeF1y0Gi/GxUNt4hyb6xDPKA==
 
-vanilla-framework@4.5.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-4.5.0.tgz#992332239682821094defaae0e8aacd343bf9239"
-  integrity sha512-35q360QpJirosK7403fSQLRPXsdabZ6LdkP2x5bqJBak3rkwmYE34wOqGbm0KggQLXSZimW5ZP2Y+0LohtAF+w==
+vanilla-framework@4.14.0:
+  version "4.14.0"
+  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-4.14.0.tgz#dca425c806462179467030ac30ef496997e2d8cb"
+  integrity sha512-YctHWwH1SbIltBMMVdeiVW1QtxVjaU15jLKiubgVjE9AByuK/EriyZnPQkXtb/+Rwf1mtF24rae+mmG8aFqUJw==
 
 verbalize@^0.1.2:
   version "0.1.2"


### PR DESCRIPTION
## Done

Bump canonicalwebteam.discourse to 5.6.1 and vanilla to 4.14.0

## QA

- Check that the changes in vanilla have not broken anything

## Issue / Card
[WD-12939](https://warthogs.atlassian.net/browse/WD-12939)

[WD-12939]: https://warthogs.atlassian.net/browse/WD-12939?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ