### PR TITLE
Update windows link

### DIFF
--- a/templates/tutorials/index.html
+++ b/templates/tutorials/index.html
@@ -20,10 +20,10 @@
   <div class="row p-section--shallow">
     <hr class="p-rule">
     <div class="col-6 col-medium-3">
-      <h2 class="p-heading--4"><a href="https://ubuntu.com/tutorials/install-microk8s-on-windows#1-overview">Install MicroK8s on Windows</a></h2>
+      <h2 class="p-heading--4"><a href="https://microk8s.io/docs/install-windows">Install MicroK8s on Windows</a></h2>
     </div>
     <div class="col-4 col-medium-2">
-      <p>Get a local Kubernetes on Windows with MicroK8s and&nbsp;Multipass.</p>
+      <p>Get a local Kubernetes on Windows.</p>
     </div>
     <div class="col-2 col-medium-1">
       <p class="p-tutorials">


### PR DESCRIPTION
## Done

The tutorial has for some reason been deleted from the tutorials site. It is better to fix this issue by linking to the maintained documentation which uses the proper method of installing for Windows.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8027/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- [List additional steps to QA the new features or prove the bug has been resolved]


## Issue / Card

Fixes #643 


