### PR TITLE
Upgrade canonicalwebteam.search to 2.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "postcss": "8.4.21",
     "postcss-cli": "10.1.0",
     "sass": "1.57.1",
-    "vanilla-framework": "4.14.0",
+    "vanilla-framework": "4.16.0",
     "webpack-cli": "5.0.1"
   },
   "devDependencies": {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-canonicalwebteam.flask-base==1.1.0
+canonicalwebteam.flask-base==2.0.0
 canonicalwebteam.discourse==5.7.1
-canonicalwebteam.search==1.3.0
+canonicalwebteam.search==2.1.1

--- a/templates/resources/videos-and-webinars.html
+++ b/templates/resources/videos-and-webinars.html
@@ -12,7 +12,7 @@
     </article>
   </div>
 </div>
-<hr>
+<hr class="p-rule" />
 <div class="row">
   <div class="col-6">
     <article class="p-section--shallow">
@@ -25,7 +25,7 @@
     </article>
   </div>
 </div>
-<hr>
+<hr class="p-rule" />
 <div class="row">
   <div class="col-6">
     <article class="p-section--shallow">
@@ -36,7 +36,7 @@
     </article>
   </div>
 </div>
-<hr>
+<hr class="p-rule" />
 <div class="row">
   <div class="col-6">
     <article class="p-section--shallow">
@@ -56,7 +56,7 @@
     </article>
   </div>
 </div>
-<hr>
+<hr class="p-rule" />
 <div class="row">
   <div class="col-6">
     <article class="p-section--shallow">
@@ -69,7 +69,7 @@
     </article>
   </div>
 </div>
-<hr>
+<hr class="p-rule" />
 <div class="row">
   <div class="col-6">
     <article class="p-section--shallow">
@@ -81,7 +81,7 @@
     </article>
   </div>
 </div>
-<hr>
+<hr class="p-rule" />
 <div class="row">
   <div class="col-6">
     <article class="p-section--shallow">
@@ -96,7 +96,7 @@
     </article>
   </div>
 </div>
-<hr>
+<hr class="p-rule" />
 <div class="row">
   <div class="col-6">
     <article class="p-section--shallow">
@@ -110,7 +110,7 @@
     </article>
   </div>
 </div>
-<hr>
+<hr class="p-rule" />
 <div class="row">
   <div class="col-6">
     <article class="p-section--shallow">
@@ -130,7 +130,7 @@
     </article>
   </div>
 </div>
-<hr>
+<hr class="p-rule" />
 <div class="row">
   <div class="col-6">
     <article class="p-section--shallow">
@@ -149,7 +149,7 @@
     </article>
   </div>
 </div>
-<hr>
+<hr class="p-rule" />
 <div class="row">
   <div class="col-6">
     <article class="p-section">
@@ -169,4 +169,4 @@
     </article>
   </div>
 </div>
-<hr>
+<hr class="p-rule" />

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -43,7 +43,6 @@ app.add_url_rule(
         session=session,
         site="microk8s.io/docs",
         template_path="docs/search.html",
-        request_limit="1/day",
     ),
 )
 discourse.init_app(app)

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -39,9 +39,11 @@ app.add_url_rule(
     "/docs/search",
     "docs-search",
     build_search_view(
+        app=app,
         session=session,
         site="microk8s.io/docs",
         template_path="docs/search.html",
+        request_limit="1/day",
     ),
 )
 discourse.init_app(app)

--- a/yarn.lock
+++ b/yarn.lock
@@ -5446,10 +5446,10 @@ validate-npm-package-license@^3.0.1:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
 
-vanilla-framework@4.14.0:
-  version "4.14.0"
-  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-4.14.0.tgz#dca425c806462179467030ac30ef496997e2d8cb"
-  integrity sha512-YctHWwH1SbIltBMMVdeiVW1QtxVjaU15jLKiubgVjE9AByuK/EriyZnPQkXtb/+Rwf1mtF24rae+mmG8aFqUJw==
+vanilla-framework@4.16.0:
+  version "4.16.0"
+  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-4.16.0.tgz#54e7a51e073de043d45a7bac37ffaa4f4351ac4a"
+  integrity sha512-LrxZLiNOm0cTpG++1X4MMy2efg8Xhc08JUAwNAybeSQ5FaaBGiAodbV1Fx3QvJxlaPFQqsjOdT6uZDwuOD7YJg==
 
 vanilla-framework@4.9.0:
   version "4.9.0"


### PR DESCRIPTION
## Done

- Upgrade canonicalwebteam.search to 2.1.1
- Upgrade canonicalwebteam.flask-base to 2.0.0
- Pass `app` to `build_search_view()`
- Bump vanilla-framework to 4.16.0
- Add `p-rule` class to `<hr>`s

## QA

- Go to https://microk8s-io-661.demos.haus/docs/search
- Search something
- See rate limit is hit (currently set to 1, so you can search 1 time before hitting it)


## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-15015

## Screenshots

![image](https://github.com/user-attachments/assets/9d3af5d2-71c2-43bd-a167-e1bc2dc869e4)
