### PR TITLE
Invoke cookie policy before gtm

### DIFF
--- a/templates/base_layout.html
+++ b/templates/base_layout.html
@@ -16,6 +16,8 @@
     <title>
       {% block title %}MicroK8s - Zero-ops Kubernetes for developers, edge and IoT{% endblock %}
     </title>
+    <!-- Cookie policy -->
+    <script src="{{ versioned_static('js/dist/cookie-policy.js') }}"></script>
     <!-- Google Analytics and Google Optimize -->
     <script>(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
   (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
@@ -116,7 +118,6 @@
       {% include "partial/_footer.html" %}
     {% endblock %}
     <script src="{{ versioned_static('js/dist/global-nav.js') }}"></script>
-    <script src="{{ versioned_static('js/dist/main.js') }}"></script>
-    <script src="{{ versioned_static('js/dist/cookie-policy.js') }}"></script>
+    <script src="{{ versioned_static('js/dist/main.js') }}"></script>    
   </body>
 </html>


### PR DESCRIPTION
## Done

- Call cookie policy before gtm

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8027/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- [List additional steps to QA the new features or prove the bug has been resolved]


## Issue / Card

Fixes #

## Screenshots

[if relevant, include a screenshot]
