### PR TITLE
WD-17308 Include H3 in docs TOC

### DIFF
--- a/templates/docs/document.html
+++ b/templates/docs/document.html
@@ -118,7 +118,14 @@
             <nav class="p-table-of-contents__nav" aria-label="Table of contents">
               <ul class="p-table-of-contents__list">
                 {% for heading in document.headings_map %}
-                <li class="p-table-of-contents__item"><a class="p-table-of-contents__link" href="#{{ heading.heading_slug }}">{{ heading.heading_text }}</a></li>
+                  <li class="p-table-of-contents__item"><a class="p-table-of-contents__link" href="#{{ heading.heading_slug }}">{{ heading.heading_text }}</a></li>
+                    {% if heading.children %}
+                      <ul class="p-table-of-contents__list">
+                        {% for child in heading.children %}
+                          <li class="p-table-of-contents__item"><a class="p-table-of-contents__link" href="#{{ child.heading_slug }}">{{ child.heading_text }}</a></li>
+                        {% endfor %}
+                      </ul>
+                    {% endif %}
                 {% endfor %}
               </ul>
             </nav>


### PR DESCRIPTION
## Done

- Include h3 headings to table of contents (displayed on the right side of the page). H3 contents should nest their parent H2 headings.

## QA

- Go to https://microk8s-io-664.demos.haus/docs/configure-host-interfaces
- Check that the table of contents on the right side of the page load as expected
- It should catch h2 and h3 headings. H3 headings should nest their corresponding H2 parent headings.


## Issue / Card

Fixes #[17308](https://warthogs.atlassian.net/browse/WD-17308)
