### PR TITLE
Mandatory company and job title fields on microk8s.io contact form

### DIFF
--- a/templates/isv/contact-us.html
+++ b/templates/isv/contact-us.html
@@ -25,11 +25,11 @@
             <h3>How should we get in touch?</h3>
             <ul class="p-list">
               <li class="p-list__item">
-                <label for="firstName">First name:</label>
+                <label class="is-required" for="firstName">First name:</label>
                 <input required id="firstName" name="firstName" maxlength="255" type="text" />
               </li>
               <li class="p-list__item">
-                <label for="lastName">Last name:</label>
+                <label class="is-required" for="lastName">Last name:</label>
                 <input required id="lastName" name="lastName" maxlength="255" type="text" />
               </li>
               <li class="p-list__item">
@@ -41,7 +41,7 @@
                 <input required id="jobTitle" name="jobTitle" maxlength="255" type="text" />
               </li>                            
               <li class="p-list__item">
-                <label for="email">Work email:</label>
+                <label class="is-required" for="email">Work email:</label>
                 <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" />
               </li>
               <li class="p-list__item">

--- a/templates/isv/contact-us.html
+++ b/templates/isv/contact-us.html
@@ -33,11 +33,11 @@
                 <input required id="lastName" name="lastName" maxlength="255" type="text" />
               </li>
               <li class="p-list__item">
-                <label for="companyName">Company name:</label>
+                <label class="is-required" for="companyName">Company name:</label>
                 <input required id="companyName" name="companyName" maxlength="255" type="text" />
               </li>
               <li class="p-list__item">
-                <label for="jobTitle">Job title:</label>
+                <label class="is-required" for="jobTitle">Job title:</label>
                 <input required id="jobTitle" name="jobTitle" maxlength="255" type="text" />
               </li>                            
               <li class="p-list__item">


### PR DESCRIPTION
## Done

- Company and Job title fields are now mandatory
- drive by: added "is-required" class to other labels with input's marked as required

## QA

- View the site in your web browser at: https://microk8s-io-666.demos.haus/isv/contact-us
- Verify the company and job title fields are mandatory

Bonus points: try to submit the form to make sure it works.


## Issue / Card

Fixes #[WD-19677](https://warthogs.atlassian.net/browse/WD-19677)


[WD-19677]: https://warthogs.atlassian.net/browse/WD-19677?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ