### PR TITLE
[WD-21210] removed unavailable media

### DIFF
--- a/templates/features/high-availability.html
+++ b/templates/features/high-availability.html
@@ -11,15 +11,6 @@
       </div>
     </div>
   </div>
-  <div class="row">
-    <div class="col-9">
-      <div class="p-section--shallow">
-        <div class="u-embedded-media u-no-margin--top">
-          <iframe class="u-embedded-media__element" src="https://www.youtube.com/embed/pRVCxNSf-Oo" width="560" height="315" title="What is MicroK8s?"></iframe>
-        </div>
-      </div>
-    </div>
-  </div>
   <hr class="p-rule">
   <div class="row">
     <div class="col-6">


### PR DESCRIPTION
## Done

- removed unavailable youtube video from "High Availability" section

## QA

- View the site in your web browser at: https://microk8s-io-668.demos.haus/features
- Verify the unavailable youtube video is removed from "High Availability" section


## Issue / Card

Fixes #[WD-21210](https://warthogs.atlassian.net/browse/WD-21210)


[WD-21210]: https://warthogs.atlassian.net/browse/WD-21210?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ