### PR TITLE
Update `K8s at the edge: easy as “Pi”` webinar link URL

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -88,7 +88,7 @@
       <p>A fully isolated deployment package protects your underlying system. Self-healing high-availability and over-the-air updates for ultra-reliable operations.</p>
       <p>MicroK8s architecture and OS compatibility allows you to deploy on COTS hardware and develop on any workstation.</p>
       <p>
-        <a href="https://www.brighttalk.com/webcast/6793/488796/kubernetes-at-the-edge-easy-as-pi">Watch the webinar: K8s at the edge: easy as “Pi”&nbsp;&rsaquo;</a>
+        <a href="https://www.brighttalk.com/webcast/6793/488796">Watch the webinar: K8s at the edge: easy as “Pi”&nbsp;&rsaquo;</a>
       </p>
     </div>
   </div>


### PR DESCRIPTION
## Done

Fix broken webinar link

## QA

- Check out [demo link](https://microk8s-io-671.demos.haus/)
- Ensure that clicking `Watch the webinar: K8s at the edge: easy as “Pi”` takes you to the correct page
![image](https://github.com/user-attachments/assets/5cab32de-94c5-4522-9974-cfdd1216cca2)

- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)


## Issue / Card

Fixes #[22343](https://warthogs.atlassian.net/browse/WD-22343)
